### PR TITLE
25 cleanup

### DIFF
--- a/ckanext/datitrentinoit/helpers.py
+++ b/ckanext/datitrentinoit/helpers.py
@@ -1,9 +1,13 @@
 import logging
+import urllib
+
 import ckan.model as model
 import ckan.plugins as p
 import ckan.lib.search as search
+import ckan.lib.helpers as h
 
 import ckan.logic as logic
+from ckan.common import request
 
 import ckanext.multilang.helpers as multilang_helpers
 
@@ -46,3 +50,22 @@ def recent_updates(n):
                 item[result.field] = result.text
 
     return search_results.get('results', [])
+
+# this is a hack against ckan-2.4.0 (until 2.4.7)
+# Early 2.4.x versions don't have helpers.current_url() and rely
+# on unescaped CKAN_CURRENT_URL env var in request. This can cause 
+# invalid redirection url in language selector.
+# Details:
+#  * 2.4.0: https://github.com/ckan/ckan/blob/ckan-2.4.0/ckan/lib/helpers.py#L277-L280
+#  * 2.4.9: https://github.com/ckan/ckan/blob/ckan-2.4.9/ckan/lib/helpers.py#L305-L313
+# fix in https://github.com/ckan/ckan/commit/109d47c1fe852085eb9bf3ba8e34d6bc6e57e3b1
+#
+# Relevant issues:
+# https://github.com/geosolutions-it/ckanext-provbz/issues/37
+# https://github.com/geosolutions-it/ckanext-provbz/issues/20#issuecomment-366279774
+def hacked_current_url():
+    try:
+        return h.current_url()
+    except AttributeError:
+        return urllib.unquote(request.environ['CKAN_CURRENT_URL'])
+

--- a/ckanext/datitrentinoit/helpers.py
+++ b/ckanext/datitrentinoit/helpers.py
@@ -1,18 +1,12 @@
 import logging
-import operator
-import json
-
-import ckan
 import ckan.model as model
 import ckan.plugins as p
 import ckan.lib.search as search
-import ckan.lib.helpers as h
 
 import ckan.logic as logic
 
 import ckanext.multilang.helpers as multilang_helpers
 
-from pylons.i18n.translation import get_lang
 from ckanext.multilang.model import PackageMultilang
 
 log = logging.getLogger(__file__)
@@ -27,8 +21,10 @@ def recent_updates(n):
                'session': model.Session,
                'user': p.toolkit.c.user or p.toolkit.c.author}
 
-    data_dict = {'rows': n, 'sort': u'metadata_modified desc', 'facet': u'false'}
-	
+    data_dict = {'rows': n,
+                 'sort': u'metadata_modified desc',
+                 'facet': u'false'}
+
     try:
         search_results = logic.get_action('package_search')(context, data_dict)
     except search.SearchError, e:
@@ -40,11 +36,13 @@ def recent_updates(n):
         log.info(':::::::::::: Retrieving the corresponding localized title and abstract :::::::::::::::')
 
         lang = multilang_helpers.getLanguage()
-        
-        q_results = model.Session.query(PackageMultilang).filter(PackageMultilang.package_id == item.get('id'), PackageMultilang.lang == lang).all() 
+
+        q_results = model.Session.query(PackageMultilang)\
+                                 .filter(PackageMultilang.package_id == item.get('id'),
+                                         PackageMultilang.lang == lang).all()
 
         if q_results:
             for result in q_results:
                 item[result.field] = result.text
-	
+
     return search_results.get('results', [])

--- a/ckanext/datitrentinoit/helpers.py
+++ b/ckanext/datitrentinoit/helpers.py
@@ -51,14 +51,17 @@ def recent_updates(n):
 
     return search_results.get('results', [])
 
-# this is a hack against ckan-2.4.0 (until 2.4.7)
-# Early 2.4.x versions don't have helpers.current_url() and rely
+# this is a hack against ckan-2.4 (versions before 2.4.7) and ckan-2.5 before ckan-2.5.6
+# Early 2.4/2.5 versions don't have helpers.current_url() and rely
 # on unescaped CKAN_CURRENT_URL env var in request. This can cause 
 # invalid redirection url in language selector.
 # Details:
 #  * 2.4.0: https://github.com/ckan/ckan/blob/ckan-2.4.0/ckan/lib/helpers.py#L277-L280
 #  * 2.4.9: https://github.com/ckan/ckan/blob/ckan-2.4.9/ckan/lib/helpers.py#L305-L313
-# fix in https://github.com/ckan/ckan/commit/109d47c1fe852085eb9bf3ba8e34d6bc6e57e3b1
+#
+# fix in 
+#        2.4: https://github.com/ckan/ckan/commit/109d47c1fe852085eb9bf3ba8e34d6bc6e57e3b1
+#        2.5: https://github.com/ckan/ckan/commit/44a82d732e8be97ac2df03c11b2659ff1a4d6e30
 #
 # Relevant issues:
 # https://github.com/geosolutions-it/ckanext-provbz/issues/37

--- a/ckanext/datitrentinoit/plugin.py
+++ b/ckanext/datitrentinoit/plugin.py
@@ -139,7 +139,8 @@ class DatiTrentinoPlugin(plugins.SingletonPlugin, DefaultTranslation):
         return {
             'dti_ga_site_id': self._get_ga_site_id,
             'dti_ga_site_domain': self._get_ga_site_domain,
-            'dti_recent_updates': helpers.recent_updates
+            'dti_recent_updates': helpers.recent_updates,
+            'hacked_current_url': helpers.hacked_current_url,
         }
 
     def _get_ga_site_id(self):

--- a/ckanext/datitrentinoit/templates/footer.html
+++ b/ckanext/datitrentinoit/templates/footer.html
@@ -29,8 +29,6 @@
 	    <i class="icon-key"></i>
 	    {{ _('Privacy') }}
 	</a></li>
-    {% block footer_links %}
-    {% endblock %}
       </ul>
     </nav>
 
@@ -43,6 +41,7 @@
 	{# <li><a href="http://okfn.org/services">{{ _('Open Knowledge Foundation') }}</a></li> #}
         {# <li><a href="http://www.okfn.org/">{{ _('Open Knowledge Foundation') }}</a></li> #}
         {# <li><a href="http://www.opendefinition.org/okd/"><img src="http://assets.okfn.org/images/ok_buttons/od_80x15_blue.png"></a></li> #}
+
       </ul>
     </nav>
 
@@ -50,8 +49,17 @@
     <div class="attribution span4" style="text-align:center;">
       {# <p><a href="http://www.provincia.tn.it/"><img src="/images/logo_prov_tn.jpg" /></a></p> #}
       <p><a href="http://www.innovazione.provincia.tn.it/opendata"><img src="/images/logo_prov_tn.jpg" /></a></p>
+
       <hr>
-      <p style="line-height:32px;">{% trans %}<strong>Powered by</strong> <a class="hide-text ckan-footer-logo" href="http://ckan.org">CKAN</a>{% endtrans %}</p>
+      <p style="line-height:32px;">
+
+        {# compat with ckanext-provbz markup in footer.html to show reports link #}
+        <ul class="unstyled" style="display: inline-block">
+        {% block header_account_settings_link %}
+        {% endblock %}
+        </ul>
+        {% trans %}<strong>Powered by</strong> <a class="hide-text ckan-footer-logo" href="http://ckan.org">CKAN</a>{% endtrans %}
+      </p>
       {% snippet "snippets/language_selector.html" %}
     </div>
 

--- a/ckanext/datitrentinoit/templates/footer.html
+++ b/ckanext/datitrentinoit/templates/footer.html
@@ -29,6 +29,8 @@
 	    <i class="icon-key"></i>
 	    {{ _('Privacy') }}
 	</a></li>
+    {% block footer_links %}
+    {% endblock %}
       </ul>
     </nav>
 

--- a/ckanext/datitrentinoit/templates/header.html
+++ b/ckanext/datitrentinoit/templates/header.html
@@ -20,7 +20,6 @@
 	("organizations_index", _("Organizations")),
 	("group_index", _("Categories")),
 	("about", _("About")),
-	('ckanext_showcase_index', _('Showcases')),
 	("faq", _('FAQ')),
 	) }}
 {% endblock %}

--- a/ckanext/datitrentinoit/templates/header.html
+++ b/ckanext/datitrentinoit/templates/header.html
@@ -20,6 +20,7 @@
 	("organizations_index", _("Organizations")),
 	("group_index", _("Categories")),
 	("about", _("About")),
+	('ckanext_showcase_index', _('Showcases')),
 	("faq", _('FAQ')),
 	) }}
 {% endblock %}

--- a/ckanext/datitrentinoit/templates/snippets/language_selector.html
+++ b/ckanext/datitrentinoit/templates/snippets/language_selector.html
@@ -1,0 +1,17 @@
+{% set current_url = h.hacked_current_url() %}
+{% set current_lang = request.environ.CKAN_LANG %}
+
+{% set default_locale = h.get_default_locale() %}
+
+<form class="form-inline form-select lang-select" action="{% url_for controller='util', action='redirect' %}" data-module="select-switch" method="POST">
+  <label for="field-lang-select">{{ _('Language') }}</label>
+  <br/>
+  <select id="field-lang-select" name="url" data-module="autocomplete" data-module-dropdown-class="lang-dropdown" data-module-container-class="lang-container">
+    {% for locale in h.get_available_locales() %}
+        <option value="{% url_for current_url, locale=locale %}" {% if locale == current_lang %}selected="selected"{% endif %}>
+          {{ locale.display_name or locale.english_name }}
+        </option>
+    {% endfor %}
+  </select>
+  <button class="btn js-hide" type="submit">{{ _('Go') }}</button>
+</form>


### PR DESCRIPTION
fix #25 
* cleanup of `helpers` module (lot of unused imports)
* added `footer_links` block into `footer.html` so ckanext-gsreport can add links there.
* added `helpers.hacked_current_url` to fix bad language selection redirection