### PR TITLE
Rimozione dei campi custom non piu necessari

### DIFF
--- a/ckanext/datitrentinoit/plugin.py
+++ b/ckanext/datitrentinoit/plugin.py
@@ -52,34 +52,6 @@ class DatiTrentinoPlugin(plugins.SingletonPlugin, DefaultTranslation):
     def get_custom_schema(self):
         return [
             {
-                'name': 'creation_date',
-                'validator': ['ignore_missing'],
-                'element': 'input',
-                'type': 'date',
-                'label': _('Creation Date'),
-                'format': '%d-%m-%Y',
-                'placeholder': _('creation date'),
-                'is_required': False,
-                'localized': False
-            },  {
-                'name': 'encoding',
-                'validator': ['ignore_missing'],
-                'element': 'input',
-                'type': 'text',
-                'label': _('Encoding'),
-                'placeholder': _('encoding type'),
-                'is_required': False,
-                'localized': False
-            }, {
-                'name': 'site_url',
-                'validator': ['ignore_missing'],
-                'element': 'input',
-                'type': 'url',
-                'label': _('Site URL'),
-                'placeholder': _('site url'),
-                'is_required': False,
-                'localized': False
-            }, {
                 'name': 'contact',
                 'validator': ['ignore_missing'],
                 'element': 'input',


### PR DESCRIPTION
Come detto per vie brevi, chiedo di rimuovere 3 dei 5 campi custom che avevamo introdotto come estensione di CKAN nel 2013 direttamente all'interno dell'estensione datitrentinoit. I due che rimangono li valutiamo ancora utili sebbene non siano parte di DCATAPIT
