### PR TITLE
Modificato i due links in homepage

### DIFF
--- a/ckanext/datitrentinoit/templates/home/index.html
+++ b/ckanext/datitrentinoit/templates/home/index.html
@@ -29,7 +29,7 @@
       <div class="text-container">
         <div><h3>{{ _("What's the weather like, today, in Trentino") }}</h3></div>
         <div class="text-row">
-          {{ _("all the <a href=\"{link}\">weather datasets</a>:").format(link='/group/dataset?q=meteo')|safe }}
+          {{ _("all the <a href=\"{link}\">weather datasets</a>:").format(link='/dataset?q=meteo')|safe }}
         </div>
         <div class="text-row">
           {{ _("daily forecasts, mountain forecasts, chances of rain")|safe }}

--- a/ckanext/datitrentinoit/templates/home/index.html
+++ b/ckanext/datitrentinoit/templates/home/index.html
@@ -29,7 +29,7 @@
       <div class="text-container">
         <div><h3>{{ _("What's the weather like, today, in Trentino") }}</h3></div>
         <div class="text-row">
-          {{ _("all the <a href=\"{link}\">weather datasets</a>:").format(link='/group/cat-meteo')|safe }}
+          {{ _("all the <a href=\"{link}\">weather datasets</a>:").format(link='/group/dataset?q=meteo')|safe }}
         </div>
         <div class="text-row">
           {{ _("daily forecasts, mountain forecasts, chances of rain")|safe }}
@@ -44,7 +44,7 @@
           {{ _("a tasty tour among typical Trentino products") }}
         </div><br>
           <div class="text-row">
-            <a href="/dataset?tags=prodotti+tipici">
+            <a href="/dataset?q=agricoltura">
               {{ _("Click here to discover more") }}
               </a>
           </div>


### PR DESCRIPTION
In conseguenza della modifica delle strutture presenti nel catalogo, e dei dataset in esso presenti, ho modificato le due URL che sono inserite come hyperlink al testo in homepage centrale. Sono entrambe delle "/dataset?q=" e non ricerce basate su TAGS e CATegorie