### PR TITLE
Removed the {% if pkg_dict.contact %} section

### DIFF
--- a/ckanext/datitrentinoit/templates/package/snippets/additional_info.html
+++ b/ckanext/datitrentinoit/templates/package/snippets/additional_info.html
@@ -37,18 +37,6 @@
           </tr>
         {% endif %}
 
-        {% if pkg_dict.contact %}
-          <tr>
-            <th scope="row" class="dataset-label">{{ _('Contact') }}</th>
-            <td class="dataset-details">{{ h.mail_to(email_address=contact or pkg_dict.contact, name=contact or pkg_dict.contact) }}</td>
-          </tr>
-        {% else %}
-          <tr>
-            <th scope="row" class="dataset-label">{{ _('Contact') }}</th>
-            <td class="dataset-details">{{ _('N/D') }}</td>
-          </tr>
-        {% endif %}
-
       {% endblock %}
     </tbody>
   </table>


### PR DESCRIPTION
In order to avoid the "Altro Contatto" field in the "Additional Metadata" section of the metadata form, I removed the following section
In facts the CKAN Package doesn't have a "contact" anymore but an Author and a Maintainer eventually
So this field it is always empty (with "N/D"), so I removed it